### PR TITLE
бафает импровы и скаттершот

### DIFF
--- a/massmeta/code/datums/components/crafting/weapon_ammo.dm
+++ b/massmeta/code/datums/components/crafting/weapon_ammo.dm
@@ -1,0 +1,11 @@
+/datum/crafting_recipe/improvisedslug
+	name = "Improvised Shotgun Shell"
+	result = /obj/item/ammo_casing/shotgun/improvised
+	reqs = list(
+		/obj/item/stack/sheet/iron = 2,
+		/obj/item/stack/cable_coil = 1,
+		/datum/reagent/fuel = 10,
+	)
+	tool_behaviors = list(TOOL_SCREWDRIVER)
+	time = 1.2 SECONDS
+	category = CAT_WEAPON_AMMO

--- a/massmeta/code/modules/ammunition/ballistic/shotgun.dm
+++ b/massmeta/code/modules/ammunition/ballistic/shotgun.dm
@@ -1,0 +1,16 @@
+/obj/item/ammo_casing/shotgun/improvised
+	name = "improvised shell"
+	desc = "An extremely weak shotgun shell with multiple small pellets made out of metal shards."
+	icon_state = "improvshell"
+	projectile_type = /obj/projectile/bullet/pellet/shotgun_improvised
+	custom_materials = list(/datum/material/iron=SMALL_MATERIAL_AMOUNT*2.5)
+	pellets = 10
+	variance = 25
+
+/obj/item/ammo_casing/shotgun/scatterlaser
+	name = "scatter laser shell"
+	desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a scatter laser weapon in a ballistic package."
+	icon_state = "lshell"
+	projectile_type = /obj/projectile/beam/scatter
+	pellets = 6
+	variance = 35

--- a/massmeta/code/modules/projectiles/projectile/beams.dm
+++ b/massmeta/code/modules/projectiles/projectile/beams.dm
@@ -1,0 +1,9 @@
+/obj/projectile/beam/scatter
+	name = "laser pellet"
+	icon_state = "scatterlaser"
+	damage = 12
+	wound_bonus = -20
+	bare_wound_bonus = 0
+	damage_falloff_tile = -0.45
+	wound_falloff_tile = -2.5
+

--- a/massmeta/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/massmeta/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -2,6 +2,7 @@
 	damage = 6
 	wound_bonus = -20
 	bare_wound_bonus = 7.5
+	damage_falloff_tile = -1.2
 	demolition_mod = 2
 	embedding = null
 

--- a/massmeta/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/massmeta/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,0 +1,10 @@
+/obj/projectile/bullet/pellet/shotgun_improvised
+	damage = 6
+	wound_bonus = -20
+	bare_wound_bonus = 7.5
+	demolition_mod = 2
+	embedding = null
+
+/obj/projectile/bullet/pellet/shotgun_improvised/Initialize(mapload)
+	. = ..()
+	range = rand(3, 8)

--- a/massmeta/includes.dm
+++ b/massmeta/includes.dm
@@ -30,3 +30,7 @@
 #include "code\game\objects\items\maintenance_loot.dm"
 #include "code\modules\reagents\chemistry\reagents\nitrium.dm"
 #include "code\modules\mob\living\simple_animal\hostile\megafauna\colossus.dm"
+#include "code\datums\components\crafting\weapon_ammo.dm"
+#include "code\modules\ammunition\ballistic\shotgun.dm"
+#include "code\modules\projectiles\projectile\bullets\shotgun.dm"
+#include "code\modules\projectiles\projectile\beams.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Убирает стекло из рецепта крафта импровов, возвращает им урон до нерфа. Убрал embedding т.к. пиздец.

Значения примерно такие же как до нерфов, но там был небольшой рефактор, так что точные значения подобрать трудно. Скаттершот немного слабее чем до нерфа (было 90, стало 72 (сейчас на оффах 45)), но его все еще можно просто напечатать в протолате после изучения.

По урону:

Импровы

Вплотную (не считая урон удара о стенку, если стоит у стены)
Ассистент - 60
Сбшник - 43

через тайл (если попадет вся дробь)
Ассистент - 48
сбшник - 27

Скаттершот

Вплотную  (не считая урон удара о стенку, если стоит у стены)
Ассистент - 72
Сбшник - 51

через тайл (если попадет вся дробь)
Ассистент - 70
сбшник - 49

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
