### PR TITLE
Квирк на робо конечности

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -24,6 +24,12 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/photophobia, /datum/quirk/nyctophobia),
 	list(/datum/quirk/item_quirk/settler, /datum/quirk/freerunning),
 	list(/datum/quirk/numb, /datum/quirk/selfaware),
+	// MASSMETA EDIT START
+	list(/datum/quirk/quadruple_amputee, /datum/quirk/augmented, /datum/quirk/frail),
+	list(/datum/quirk/quadruple_amputee, /datum/quirk/augmented, /datum/quirk/paraplegic),
+	list(/datum/quirk/quadruple_amputee, /datum/quirk/augmented, /datum/quirk/paraplegic),
+	list(/datum/quirk/prosthetic_limb, /datum/quirk/quadruple_amputee, /datum/quirk/augmented, /datum/quirk/body_purist),
+	// MASSMETA EDIT END
 ))
 
 GLOBAL_LIST_INIT(quirk_string_blacklist, generate_quirk_string_blacklist())

--- a/massmeta/code/datums/quirks/positive_quirks/augmented.dm
+++ b/massmeta/code/datums/quirks/positive_quirks/augmented.dm
@@ -1,0 +1,19 @@
+/datum/quirk/augmented
+	name = "Augmented"
+	desc = "All your limbs are replaced with robotic ones, which are more durable, but are vulnerable to EMPs and can be healed only by welding tools and cable coils."
+	icon = "tg-prosthetic-full"
+	value = 8
+	medical_record_text = "During physical examination, patient was found to have all robotic limbs."
+	quirk_flags = QUIRK_HUMAN_ONLY | QUIRK_CHANGES_APPEARANCE
+
+/datum/quirk/augmented/add_unique(client/client_source)
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/arm/left/robot)
+	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/arm/right/robot)
+	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/left/robot)
+	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/right/robot)
+	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/chest/robot)
+	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/head/robot)
+/datum/quirk/augmented/post_add()
+	to_chat(quirk_holder, span_boldannounce("All your limbs have been replaced with robotic ones. They are more durable and reistant to damage. Additionally, \
+	you need to use a welding tool and cables to repair them, instead of bruise packs and ointment."))

--- a/massmeta/code/datums/quirks/positive_quirks/augmented.dm
+++ b/massmeta/code/datums/quirks/positive_quirks/augmented.dm
@@ -2,7 +2,7 @@
 	name = "Augmented"
 	desc = "All your limbs are replaced with robotic ones, which are more durable, but are vulnerable to EMPs and can be healed only by welding tools and cable coils."
 	icon = "tg-prosthetic-full"
-	value = 8
+	value = 4
 	medical_record_text = "During physical examination, patient was found to have all robotic limbs."
 	quirk_flags = QUIRK_HUMAN_ONLY | QUIRK_CHANGES_APPEARANCE
 
@@ -12,8 +12,7 @@
 	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/arm/right/robot)
 	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/left/robot)
 	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/right/robot)
-	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/chest/robot)
-	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/head/robot)
+
 /datum/quirk/augmented/post_add()
 	to_chat(quirk_holder, span_boldannounce("All your limbs have been replaced with robotic ones. They are more durable and reistant to damage. Additionally, \
 	you need to use a welding tool and cables to repair them, instead of bruise packs and ointment."))

--- a/massmeta/includes.dm
+++ b/massmeta/includes.dm
@@ -113,5 +113,6 @@
 #include "code\modules\hooch.dm"
 #include "code\__DEFINES\text.dm"
 #include "code\datums\brain_damage\mild.dm"
+#include "code\datums\quirks\positive_quirks\augmented.dm"
 //features
 #include "features\additional_circuit\includes.dm"


### PR DESCRIPTION
Добавляет квирк на нормальные робо конечности, стоит 4 поинта. Взято со старого репо.