### PR TITLE
Изменение минимального количества игроков для объявления войны

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -11,7 +11,7 @@
 #define NUKE_RESULT_HIJACK_NO_DISK 10
 
 /// Min players requireed for nukes to declare war
-#define CHALLENGE_MIN_PLAYERS 50
+#define CHALLENGE_MIN_PLAYERS 25	// MASSMETA EDIT
 
 //fugitive end results
 #define FUGITIVE_RESULT_BADASS_HUNTER 0

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -1,6 +1,11 @@
 #define CHALLENGE_TELECRYSTALS 280
 #define CHALLENGE_TIME_LIMIT (5 MINUTES)
 #define CHALLENGE_SHUTTLE_DELAY (25 MINUTES) // 25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
+// MASSMETA EDIT START
+#define WAR_TC_MIN 125
+#define WAR_TC_MAX 280
+#define WAR_MAX_PAYOUT 50
+// MASSMETA EDIT END
 
 GLOBAL_LIST_EMPTY(jam_on_wardec)
 
@@ -22,7 +27,11 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 		return
 
 	declaring_war = TRUE
-	var/are_you_sure = tgui_alert(user, "Consult your team carefully before you declare war on [station_name()]. Are you sure you want to alert the enemy crew? You have [DisplayTimeText(CHALLENGE_TIME_LIMIT - world.time - SSticker.round_start_time)] to decide.", "Declare war?", list("Yes", "No"))
+// MASSMETA EDIT START
+	var/are_you_sure = tgui_alert(user, "Consult your team carefully before you declare war on [station_name()]]. Are you sure you want to alert the enemy crew? You will get \
+		[round(WAR_TC_MIN + (WAR_TC_MAX - WAR_TC_MIN) * (1 - (WAR_MAX_PAYOUT - min(WAR_MAX_PAYOUT, GLOB.joined_player_list.len)) / (WAR_MAX_PAYOUT - CHALLENGE_MIN_PLAYERS)), 1)] \
+		extra telecystals. You have [DisplayTimeText(CHALLENGE_TIME_LIMIT - world.time - SSticker.round_start_time)] to decide", "Declare war?", list("Yes", "No"))
+// MASSMETA EDIT END
 	declaring_war = FALSE
 
 	if(!check_allowed(user))
@@ -114,7 +123,7 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 			continue
 		uplinks += uplink
 
-	var/tc_to_distribute = CHALLENGE_TELECRYSTALS
+	var/tc_to_distribute = round(WAR_TC_MIN + (WAR_TC_MAX - WAR_TC_MIN) * (1 - (WAR_MAX_PAYOUT - min(WAR_MAX_PAYOUT, GLOB.joined_player_list.len)) / (WAR_MAX_PAYOUT - CHALLENGE_MIN_PLAYERS)), 1)	// MASSMETA EDIT
 	var/tc_per_nukie = round(tc_to_distribute / (length(orphans)+length(uplinks)))
 
 	for (var/datum/component/uplink/uplink in uplinks)
@@ -197,3 +206,8 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 #undef CHALLENGE_TELECRYSTALS
 #undef CHALLENGE_TIME_LIMIT
 #undef CHALLENGE_SHUTTLE_DELAY
+// MASSMETA EDIT START
+#undef WAR_TC_MIN
+#undef WAR_TC_MAX
+#undef WAR_MAX_PAYOUT
+// MASSMETA EDIT END


### PR DESCRIPTION
## About The Pull Request
Меняет минимальное количество игроков для объявления войны на 25 и дает от 125 до 280 тк в зависимости от количества игроков в раунде (280 тк при 50 стандартных игроках)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Изменение минимального количества игроков для войны на 25 и скейл тк с кол-вом игроков в раунде.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
